### PR TITLE
Fix issues when using tap-zendesk

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -66,7 +66,6 @@ def flatten_key(k, parent_key, sep):
 
 def flatten_schema(d, parent_key=[], sep='__'):
     items = []
-    print("{}\n".format(d['properties']))
     for k, v in d['properties'].items():
         new_key = flatten_key(k, parent_key, sep)
 


### PR DESCRIPTION
This PR fixes two issues when using `tap-zendesk` alongside this target:

  1. Empty property declaration.

The discovery of `tap-zendesk` outputs empty property declarations and it caused the `flatten_schema` function to raise an **IndexError**. Now we ignore these.

  2. \u0000 character in the CSV payload

In a certain entry, I had a `\\u0000` sequence that was being escaped twice by `json.dumps`. I've simply added some sanitization before sending the CSV line to remove this sequence.