### PR TITLE
Fix to load zero values

### DIFF
--- a/target_postgres/db_sync.py
+++ b/target_postgres/db_sync.py
@@ -150,7 +150,7 @@ class DbSync:
         flatten = flatten_record(record)
         return ','.join(
             [
-                json.dumps(flatten[name]) if name in flatten and flatten[name] else ''
+                json.dumps(flatten[name]) if name in flatten and (flatten[name] == 0 or flatten[name]) else ''
                 for name in self.flatten_schema
             ]
         )


### PR DESCRIPTION
Zero numeric values are evaluated as False and always loaded as NULL into postgres.
Added an extra numeric condition to avoid this: `flatten[name] == 0`