### PR TITLE
Fixed multipleOf validation issue: convert float to Decimal

### DIFF
--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -13,12 +13,23 @@ import collections
 from tempfile import TemporaryFile
 
 import pkg_resources
-from jsonschema.validators import Draft4Validator
+from jsonschema.validators import Draft4Validator, FormatChecker
 import singer
 from target_postgres.db_sync import DbSync
 
 logger = singer.get_logger()
 
+
+def float_to_decimal(value):
+    '''Walk the given data structure and turn all instances of float into
+    double.'''
+    if isinstance(value, float):
+        return Decimal(str(value))
+    if isinstance(value, list):
+        return [float_to_decimal(child) for child in value]
+    if isinstance(value, dict):
+        return {k: float_to_decimal(v) for k, v in value.items()}
+    return value
 
 def emit_state(state):
     if state is not None:
@@ -65,7 +76,7 @@ def persist_lines(config, lines):
             stream = o['stream']
 
             # Validate record
-            validators[stream].validate(o['record'])
+            validators[stream].validate(float_to_decimal(o['record']))
 
             sync = stream_to_sync[stream]
 
@@ -93,7 +104,8 @@ def persist_lines(config, lines):
                 raise Exception("Line is missing required key 'stream': {}".format(line))
             stream = o['stream']
             schemas[stream] = o
-            validators[stream] = Draft4Validator(o['schema'])
+            schema = float_to_decimal(o['schema'])
+            validators[stream] = Draft4Validator(schema, format_checker=FormatChecker())
             if 'key_properties' not in o:
                 raise Exception("key_properties field is required")
             key_properties[stream] = o['key_properties']

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -13,7 +13,8 @@ import collections
 from tempfile import TemporaryFile
 
 import pkg_resources
-from jsonschema.validators import Draft4Validator, FormatChecker
+from jsonschema import Draft4Validator, FormatChecker
+from decimal import Decimal
 import singer
 from target_postgres.db_sync import DbSync
 


### PR DESCRIPTION
Failing to load floats into Postgres when the values are validated by `"multipleOf": x` in the schema. This is reported in issue #6 and I was facing the same problem .

The reason is that `multipleOf` requires values as Decimals and we need to convert the input floats to Decimals to work correctly. The idea and the logic is copied from [target-stitch](https://github.com/singer-io/target-stitch/blob/master/target_stitch/__init__.py#L96)